### PR TITLE
bcrypt builtin function

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/hil"
 	"github.com/hashicorp/hil/ast"
 	"github.com/mitchellh/go-homedir"
+	"golang.org/x/crypto/bcrypt"
 )
 
 // stringSliceToVariableValue converts a string slice into the value
@@ -59,6 +60,7 @@ func Funcs() map[string]ast.Function {
 		"base64encode": interpolationFuncBase64Encode(),
 		"base64sha256": interpolationFuncBase64Sha256(),
 		"base64sha512": interpolationFuncBase64Sha512(),
+		"bcrypt":       interpolationFuncBcrypt(),
 		"ceil":         interpolationFuncCeil(),
 		"chomp":        interpolationFuncChomp(),
 		"cidrhost":     interpolationFuncCidrHost(),
@@ -1318,6 +1320,40 @@ func interpolationFuncBase64Sha512() ast.Function {
 			shaSum := h.Sum(nil)
 			encoded := base64.StdEncoding.EncodeToString(shaSum[:])
 			return encoded, nil
+		},
+	}
+}
+
+func interpolationFuncBcrypt() ast.Function {
+	return ast.Function{
+		ArgTypes:     []ast.Type{ast.TypeString},
+		Variadic:     true,
+		VariadicType: ast.TypeString,
+		ReturnType:   ast.TypeString,
+		Callback: func(args []interface{}) (interface{}, error) {
+			defaultCost := 10
+
+			if len(args) > 1 {
+				costStr := args[1].(string)
+				cost, err := strconv.Atoi(costStr)
+				if err != nil {
+					return "", err
+				}
+
+				defaultCost = cost
+			}
+
+			if len(args) > 2 {
+				return "", fmt.Errorf("bcrypt() takes no more than two arguments")
+			}
+
+			input := args[0].(string)
+			out, err := bcrypt.GenerateFromPassword([]byte(input), defaultCost)
+			if err != nil {
+				return "", fmt.Errorf("error occured generating password %s", err.Error())
+			}
+
+			return string(out), nil
 		},
 	}
 }

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/hil"
 	"github.com/hashicorp/hil/ast"
 	"github.com/mitchellh/go-homedir"
+	"golang.org/x/crypto/bcrypt"
 )
 
 func TestInterpolateFuncZipMap(t *testing.T) {
@@ -2431,6 +2432,34 @@ func TestInterpolateFuncSubstr(t *testing.T) {
 			},
 			{
 				`${substr("", 0, -2)}`,
+				nil,
+				true,
+			},
+		},
+	})
+}
+
+func TestInterpolateFuncBcrypt(t *testing.T) {
+	node, err := hil.Parse(`${bcrypt("test")}`)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	result, err := hil.Eval(node, langEvalConfig(nil))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	err = bcrypt.CompareHashAndPassword([]byte(result.Value.(string)), []byte("test"))
+
+	if err != nil {
+		t.Fatalf("Error comparing hash and password: %s", err)
+	}
+
+	testFunction(t, testFunctionConfig{
+		Cases: []testFunctionCase{
+			//Negative test for more than two parameters
+			{
+				`${bcrypt("test", 15, 12)}`,
 				nil,
 				true,
 			},

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -163,6 +163,9 @@ The supported built-in functions are:
     **This is not equivalent** of `base64encode(sha512(string))`
     since `sha512()` returns hexadecimal representation.
 
+  * `bcrypt(password, cost)` - Returns the Blowfish encrypted hash of the string 
+    at the given cost. A default `cost` of 10 will be used if not provided.
+
   * `ceil(float)` - Returns the least integer value greater than or equal
       to the argument.
 


### PR DESCRIPTION
## Feature Proposal
### Problem
Users need to provide passwords as strings that need to be encrypted with bcrypt through Terraform [builtin functions](https://www.terraform.io/docs/configuration/interpolation.html). 

- **bcrypt** is a [password hashing function](https://en.wikipedia.org/wiki/Cryptographic_hash_function#Password_verification) based on the [Blowfish cipher.](https://en.wikipedia.org/wiki/Blowfish_(cipher))

### Proposed Solution

- Add  a new **bcrypt** function to the built-in Terraform interpolation functions.
- The function would generate hash from password using https://godoc.org/golang.org/x/crypto/bcrypt#GenerateFromPassword 
- **bcrypt** will have variable number of string arguments to allow users to pass optional parameter cost. Only the first argument would be accepted, If cost parameter is not provided it will default to 10. Return type will be string.
### Required Dependencies
The Go library will be used for the built-in interpolation function.
-golang.org/x/crypto/bcrypt/bcrypt.go
### Example Usage
Prior HCL with password string:

```
admin_password_hash = "$2a$15$JhQLJz1I1.O8elxxeGfFMuMPAPC3GxiAnW4AU7G0eEu92T6YVHDiO"
```

New HCL with the **bcrypt** function:

With default `cost` value:
```
admin_password = "${bcrypt(“1234”)}"
```
With custom `cost` value:
```
admin_password = "${bcrypt(“1234”, 15)}"
```

/c @edevenport Let's use this as a dry run. 